### PR TITLE
Fixed landing detection condition to be just "variance < value"

### DIFF
--- a/Firmware/MainDev/main.c
+++ b/Firmware/MainDev/main.c
@@ -700,7 +700,7 @@ void rawdata_readout_cycle (uint16_t *eeprom_address, uint8_t process_type)
 								variance += term*term;
 							}
 							variance /= BMP280_CYCLES_NUM_LANDED;
-							if((variance > 0) && (variance < MAX_VARIANCE_LANDING_DETECT))
+							if(variance < MAX_VARIANCE_LANDING_DETECT)
 							{
 								en_flags.rawdata_readout = FALSE;
 


### PR DESCRIPTION
Because variance can never be negative, so it's a waste to test for "(variance > 0) && (variance < value)" .